### PR TITLE
Fixed txt header not rendering correctly and updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ import (
 
 func init() {
     if envy.Get("GO_ENV", "development") == "development" {
-        Sender = mailopen.WithOptions(mailopen.OpenOnly("text/html"))
+        Sender = mailopen.WithOptions(mailopen.Only("text/html"))
         
 		return
     }

--- a/filesender.go
+++ b/filesender.go
@@ -110,7 +110,7 @@ func (ps FileSender) Send(m mail.Message) error {
 		)
 
 		var re = regexp.MustCompile(cc.replaceRegexp)
-		content := re.ReplaceAllString(v.Content, fmt.Sprintf(`$1%v$2$3`, header))
+		content := re.ReplaceAllString(v.Content, header)
 
 		path, err := ps.saveEmailBody(content, fmt.Sprint(index), m)
 		if err != nil {

--- a/mailopen_test.go
+++ b/mailopen_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gobuffalo/buffalo/mail"
@@ -20,6 +21,15 @@ type falseSender struct{}
 func (ps falseSender) Send(m mail.Message) error {
 	return nil
 }
+
+const (
+	txtFormat = `From: %v <br>
+		To: %v <br>
+		Cc: %v <br>
+		Bcc: %v <br>
+		Subject: %v <br>
+		----------------------------`
+)
 
 func Test_Send(t *testing.T) {
 	mailopen.Testing = true
@@ -55,27 +65,93 @@ func Test_Send(t *testing.T) {
 	r.FileExists(htmlFile)
 	r.FileExists(txtFile)
 
-	dat, err := ioutil.ReadFile(htmlFile)
+	txtHeader, err := ioutil.ReadFile(htmlFile)
 	r.NoError(err)
 
-	r.Contains(string(dat), m.From)
-	r.Contains(string(dat), m.To[0])
-	r.Contains(string(dat), m.CC[0])
-	r.Contains(string(dat), m.Bcc[0])
-	r.Contains(string(dat), m.Subject)
+	r.Contains(string(txtHeader), m.From)
+	r.Contains(string(txtHeader), m.To[0])
+	r.Contains(string(txtHeader), m.CC[0])
+	r.Contains(string(txtHeader), m.Bcc[0])
+	r.Contains(string(txtHeader), m.Subject)
 
 	for _, a := range m.Attachments {
-		r.Contains(string(dat), a.Name)
+		r.Contains(string(txtHeader), a.Name)
 	}
 
-	dat, err = ioutil.ReadFile(txtFile)
+	txtHeader, err = ioutil.ReadFile(txtFile)
 	r.NoError(err)
 
-	r.Contains(string(dat), m.From)
-	r.Contains(string(dat), m.To[0])
-	r.Contains(string(dat), m.CC[0])
-	r.Contains(string(dat), m.Bcc[0])
-	r.Contains(string(dat), m.Subject)
+	r.Contains(string(txtHeader), m.From)
+	r.Contains(string(txtHeader), m.To[0])
+	r.Contains(string(txtHeader), m.CC[0])
+	r.Contains(string(txtHeader), m.Bcc[0])
+	r.Contains(string(txtHeader), m.Subject)
+
+	format := strings.ReplaceAll(txtFormat, "\t", "")
+
+	r.Equal(string(txtHeader), fmt.Sprintf(format, m.From, m.To[0], m.CC[0], m.Bcc[0], m.Subject))
+}
+
+func Test_SendWithOptionsOnlyHTML(t *testing.T) {
+	r := require.New(t)
+
+	mailopen.Testing = true
+
+	sender := mailopen.WithOptions(mailopen.Only("text/html"))
+	sender.Open = false
+
+	m := mail.NewMessage()
+	m.From = "testing@testing.com"
+	m.To = []string{"testing@other.com"}
+	m.CC = []string{"aa@other.com"}
+	m.Bcc = []string{"aax@other.com"}
+	m.Subject = "something"
+	m.Bodies = []mail.Body{
+		{ContentType: "text/html", Content: "<html><head></head><body><div>Some Message</div></body></html>"},
+		{ContentType: "text/plain", Content: "Same message"},
+	}
+
+	htmlFile := path.Join(sender.TempDir, fmt.Sprintf("%s_0.html", flect.Underscore(m.Subject)))
+	txtFile := path.Join(sender.TempDir, fmt.Sprintf("%s_1.html", flect.Underscore(m.Subject)))
+
+	os.Remove(htmlFile)
+	os.Remove(txtFile)
+
+	r.NoError(sender.Send(m))
+
+	r.FileExists(htmlFile)
+	r.NoFileExists(txtFile)
+}
+
+func Test_SendWithOptionsOnlyTXT(t *testing.T) {
+	r := require.New(t)
+
+	mailopen.Testing = true
+
+	sender := mailopen.WithOptions(mailopen.Only("text/plain"))
+	sender.Open = false
+
+	m := mail.NewMessage()
+	m.From = "testing@testing.com"
+	m.To = []string{"testing@other.com"}
+	m.CC = []string{"aa@other.com"}
+	m.Bcc = []string{"aax@other.com"}
+	m.Subject = "something"
+	m.Bodies = []mail.Body{
+		{ContentType: "text/html", Content: "<html><head></head><body><div>Some Message</div></body></html>"},
+		{ContentType: "text/plain", Content: "Same message"},
+	}
+
+	htmlFile := path.Join(sender.TempDir, fmt.Sprintf("%s_0.html", flect.Underscore(m.Subject)))
+	txtFile := path.Join(sender.TempDir, fmt.Sprintf("%s_1.html", flect.Underscore(m.Subject)))
+
+	os.Remove(htmlFile)
+	os.Remove(txtFile)
+
+	r.NoError(sender.Send(m))
+
+	r.NoFileExists(htmlFile)
+	r.FileExists(txtFile)
 }
 
 func Test_SendWithOneBody(t *testing.T) {

--- a/plain-header.txt
+++ b/plain-header.txt
@@ -1,6 +1,6 @@
-From: %v
-To: %v
-Cc: %v
-Bcc: %v 
-Subject: %v
+From: %v <br>
+To: %v <br>
+Cc: %v <br>
+Bcc: %v <br>
+Subject: %v <br>
 ----------------------------


### PR DESCRIPTION
When using the text/plain option, the header was missing the **From** and all the content was displaying in a single line.