### PR TITLE
fix: txt format and html body not rendering properly

### DIFF
--- a/filesender.go
+++ b/filesender.go
@@ -110,7 +110,7 @@ func (ps FileSender) Send(m mail.Message) error {
 		)
 
 		var re = regexp.MustCompile(cc.replaceRegexp)
-		content := re.ReplaceAllString(v.Content, header)
+		content := re.ReplaceAllString(v.Content, fmt.Sprintf("$1\n%v\n$2$3", header))
 
 		path, err := ps.saveEmailBody(content, fmt.Sprint(index), m)
 		if err != nil {

--- a/mailopen_test.go
+++ b/mailopen_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/gobuffalo/buffalo/mail"
@@ -86,9 +85,7 @@ func Test_Send(t *testing.T) {
 	r.Contains(string(txtContent), m.Subject)
 	r.Contains(string(txtContent), "Some message")
 
-	format := strings.ReplaceAll(txtFormat, "\t", "")
-
-	r.Contains(string(txtContent), fmt.Sprintf(format, m.From, m.To[0], m.CC[0], m.Bcc[0], m.Subject))
+	r.Contains(string(txtContent), fmt.Sprintf(txtFormat, m.From, m.To[0], m.CC[0], m.Bcc[0], m.Subject))
 }
 
 func Test_SendWithOptionsOnlyHTML(t *testing.T) {


### PR DESCRIPTION
On the previous PR, I forgot to add back the “fmt.Sprintf” that replaced the content, this caused that the body content wasn't rendering properly. 

This PR fixes the render problem and also keeping the TXT header in the correct format. 
