### PR TITLE
feat: implemented option to use a custom directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ func init() {
 
 Then you will use your `Sender` instance as usual by calling `Sender.Send(m)` with the variant that in development it will open your emails in the browser.
 
+By default, mailopen will save the emails and attachments in a temporary directory. You can customize this by passing options to the [`mailopen.WithOptions`](#options) or setting the `MAILOPEN_DIR` env variable in your machine.
+
 ### Options
 
 You can pass options to the `mailopen.WithOptions` function to customize the way it work.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Mailopen is a buffalo mailer that allows to see sent emails in the browser inste
 
 ### Usage
 
-Mailopen is only intended for development purposes, the way you use it is by simply initialyzing your mailer to be a mailopen instance instead of your regular sender, p.e:
+Mailopen is only intended for development purposes, the way you use it is by simply initializing your mailer to be a mailopen instance instead of your regular sender, p.e:
 
 ```go
 import (
@@ -49,3 +49,12 @@ func init() {
 ```
 
 Then you will use your `Sender` instance as usual by calling `Sender.Send(m)` with the variant that in development it will open your emails in the browser.
+
+### Options
+
+You can pass options to the `mailopen.WithOptions` function to customize the way it work.
+
+- `Only` allows you to specify which content types you want to open in the browser, p.e: `mailopen.Only("text/html")`.
+
+- `Directory` allows you to specify the directory where the emails and attachments will be saved, p.e: `mailopen.Directory("/tmp")`.
+

--- a/filesender.go
+++ b/filesender.go
@@ -54,8 +54,9 @@ type contentConfig struct {
 // FileSender implements the Sender interface to be used
 // within buffalo mailer generated package.
 type FileSender struct {
-	Open    bool
-	TempDir string
+	Open bool
+	// dir is the directory to save the files to (attachments and email templates).
+	dir string
 
 	// openContentTypes are those content types to open in browser
 	openContentTypes []string
@@ -150,7 +151,7 @@ func (ps FileSender) saveEmailBody(content, tmpName string, m mail.Message) (str
 		filePath = fmt.Sprintf("%s.html", tmpName)
 	}
 
-	path := path.Join(ps.TempDir, filePath)
+	path := path.Join(ps.dir, filePath)
 	err = os.WriteFile(path, tpl.Bytes(), 0644)
 
 	return path, err
@@ -169,9 +170,9 @@ func (ps FileSender) saveAttachmentFiles(Attachments []mail.Attachment) ([]AttFi
 			return []AttFile{}, fmt.Errorf("mailopen: failed to get extension for content type %s: %w", a.ContentType, err)
 		}
 
-		filePath := path.Join(ps.TempDir, fmt.Sprintf("%s_%s%s", uuid.Must(uuid.NewV4()), a.Name, exts[0]))
+		filePath := path.Join(ps.dir, fmt.Sprintf("%s_%s%s", uuid.Must(uuid.NewV4()), a.Name, exts[0]))
 		if Testing {
-			filePath = path.Join(ps.TempDir, fmt.Sprintf("%s%s", a.Name, exts[0]))
+			filePath = path.Join(ps.dir, fmt.Sprintf("%s%s", a.Name, exts[0]))
 		}
 
 		b, err := io.ReadAll(a.Reader)

--- a/mailopen.go
+++ b/mailopen.go
@@ -7,6 +7,8 @@ import (
 
 var Testing = false
 
+const MailOpenDirKey = "MAILOPEN_DIR"
+
 // New creates a sender that writes emails into disk
 func New() FileSender {
 	fmt.Println("Deprecated: use WithOptions instead.")
@@ -19,7 +21,7 @@ func New() FileSender {
 func WithOptions(options ...Option) FileSender {
 	s := FileSender{
 		Open: true,
-		dir:  os.TempDir(),
+		dir:  getEnv(MailOpenDirKey, os.TempDir()),
 	}
 
 	for _, option := range options {
@@ -27,4 +29,11 @@ func WithOptions(options ...Option) FileSender {
 	}
 
 	return s
+}
+
+func getEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
 }

--- a/mailopen.go
+++ b/mailopen.go
@@ -18,8 +18,8 @@ func New() FileSender {
 // And applies the passed options.
 func WithOptions(options ...Option) FileSender {
 	s := FileSender{
-		Open:    true,
-		TempDir: os.TempDir(),
+		Open: true,
+		dir:  os.TempDir(),
 	}
 
 	for _, option := range options {

--- a/mailopen_test.go
+++ b/mailopen_test.go
@@ -179,6 +179,26 @@ func Test_Send(t *testing.T) {
 
 		r.Error(sender.Send(m))
 	})
+
+	t.Run("with custom folder", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		os.Setenv(mailopen.MailOpenDirKey, tmpDir)
+		sender := mailopen.WithOptions()
+		sender.Open = false
+
+		m.Bodies = []mail.Body{
+			{ContentType: "text/html", Content: testHTMLcontent},
+			{ContentType: "text/plain", Content: "Same message"},
+		}
+
+		r.NoError(sender.Send(m))
+
+		htmlFile := path.Join(tmpDir, fmt.Sprintf("%s_body.html", strings.ReplaceAll(m.Bodies[0].ContentType, "/", "_")))
+		txtFile := path.Join(tmpDir, fmt.Sprintf("%s_body.html", strings.ReplaceAll(m.Bodies[1].ContentType, "/", "_")))
+
+		r.FileExists(htmlFile)
+		r.FileExists(txtFile)
+	})
 }
 
 func Test_Wrap(t *testing.T) {

--- a/mailopen_test.go
+++ b/mailopen_test.go
@@ -41,9 +41,9 @@ func Test_Send(t *testing.T) {
 	const testHTMLcontent = `<html><head></head><body><div>Some Message</div></body></html>`
 
 	t.Run("html and plain with attachments", func(t *testing.T) {
-		sender := mailopen.WithOptions()
+		tmpDir := t.TempDir()
+		sender := mailopen.WithOptions(mailopen.Directory(tmpDir))
 		sender.Open = false
-		sender.TempDir = t.TempDir()
 
 		m.Bodies = []mail.Body{
 			{ContentType: "text/html", Content: testHTMLcontent},
@@ -60,8 +60,8 @@ func Test_Send(t *testing.T) {
 
 		r.NoError(sender.Send(m))
 
-		htmlFile := path.Join(sender.TempDir, fmt.Sprintf("%s_body.html", strings.ReplaceAll(m.Bodies[0].ContentType, "/", "_")))
-		txtFile := path.Join(sender.TempDir, fmt.Sprintf("%s_body.html", strings.ReplaceAll(m.Bodies[1].ContentType, "/", "_")))
+		htmlFile := path.Join(tmpDir, fmt.Sprintf("%s_body.html", strings.ReplaceAll(m.Bodies[0].ContentType, "/", "_")))
+		txtFile := path.Join(tmpDir, fmt.Sprintf("%s_body.html", strings.ReplaceAll(m.Bodies[1].ContentType, "/", "_")))
 
 		r.FileExists(htmlFile)
 		r.FileExists(txtFile)
@@ -81,7 +81,7 @@ func Test_Send(t *testing.T) {
 			ext, err := mime.ExtensionsByType(a.ContentType)
 			r.NoError(err)
 
-			filePath := path.Join(sender.TempDir, fmt.Sprintf("%s%s", a.Name, ext[0]))
+			filePath := path.Join(tmpDir, fmt.Sprintf("%s%s", a.Name, ext[0]))
 			r.FileExists(filePath)
 		}
 
@@ -99,17 +99,17 @@ func Test_Send(t *testing.T) {
 	})
 
 	t.Run("html only", func(t *testing.T) {
-		sender := mailopen.WithOptions(mailopen.Only("text/html"))
+		tmpDir := t.TempDir()
+		sender := mailopen.WithOptions(mailopen.Only("text/html"), mailopen.Directory(tmpDir))
 		sender.Open = false
-		sender.TempDir = t.TempDir()
 
 		m.Bodies = []mail.Body{
 			{ContentType: "text/html", Content: testHTMLcontent},
 			{ContentType: "text/plain", Content: "Same message"},
 		}
 
-		htmlFile := path.Join(sender.TempDir, fmt.Sprintf("%s_body.html", strings.ReplaceAll(m.Bodies[0].ContentType, "/", "_")))
-		txtFile := path.Join(sender.TempDir, fmt.Sprintf("%s_body.html", strings.ReplaceAll(m.Bodies[1].ContentType, "/", "_")))
+		htmlFile := path.Join(tmpDir, fmt.Sprintf("%s_body.html", strings.ReplaceAll(m.Bodies[0].ContentType, "/", "_")))
+		txtFile := path.Join(tmpDir, fmt.Sprintf("%s_body.html", strings.ReplaceAll(m.Bodies[1].ContentType, "/", "_")))
 
 		r.NoError(sender.Send(m))
 
@@ -123,17 +123,17 @@ func Test_Send(t *testing.T) {
 	})
 
 	t.Run("plain only", func(t *testing.T) {
-		sender := mailopen.WithOptions(mailopen.Only("text/plain"))
+		tmpDir := t.TempDir()
+		sender := mailopen.WithOptions(mailopen.Only("text/plain"), mailopen.Directory(tmpDir))
 		sender.Open = false
-		sender.TempDir = t.TempDir()
 
 		m.Bodies = []mail.Body{
 			{ContentType: "text/html", Content: testHTMLcontent},
 			{ContentType: "text/plain", Content: "Same message"},
 		}
 
-		htmlFile := path.Join(sender.TempDir, fmt.Sprintf("%s_body.html", strings.ReplaceAll(m.Bodies[0].ContentType, "/", "_")))
-		txtFile := path.Join(sender.TempDir, fmt.Sprintf("%s_body.html", strings.ReplaceAll(m.Bodies[1].ContentType, "/", "_")))
+		htmlFile := path.Join(tmpDir, fmt.Sprintf("%s_body.html", strings.ReplaceAll(m.Bodies[0].ContentType, "/", "_")))
+		txtFile := path.Join(tmpDir, fmt.Sprintf("%s_body.html", strings.ReplaceAll(m.Bodies[1].ContentType, "/", "_")))
 
 		r.NoError(sender.Send(m))
 
@@ -142,9 +142,9 @@ func Test_Send(t *testing.T) {
 	})
 
 	t.Run("long subject and long file name`", func(t *testing.T) {
-		sender := mailopen.WithOptions()
+		tmpDir := t.TempDir()
+		sender := mailopen.WithOptions(mailopen.Directory(tmpDir))
 		sender.Open = false
-		sender.TempDir = t.TempDir()
 
 		m := mail.NewMessage()
 
@@ -165,14 +165,13 @@ func Test_Send(t *testing.T) {
 		exts, err := mime.ExtensionsByType(att.ContentType)
 		r.NoError(err)
 
-		filePath := path.Join(sender.TempDir, fmt.Sprintf("%s%s", att.Name[0:50], exts[0]))
+		filePath := path.Join(tmpDir, fmt.Sprintf("%s%s", att.Name[0:50], exts[0]))
 		r.FileExists(filePath)
 	})
 
 	t.Run("only one body", func(t *testing.T) {
-		sender := mailopen.WithOptions()
+		sender := mailopen.WithOptions(mailopen.Directory(t.TempDir()))
 		sender.Open = false
-		sender.TempDir = t.TempDir()
 
 		m.Bodies = []mail.Body{
 			{ContentType: "text/html", Content: testHTMLcontent},

--- a/option.go
+++ b/option.go
@@ -10,3 +10,11 @@ func Only(contentTypes ...string) Option {
 		fo.openContentTypes = contentTypes
 	}
 }
+
+// Directory sets the directory to save the files to (attachments and email templates).
+// If not set, the default is os.TempDir().
+func Directory(dir string) Option {
+	return func(fo *FileSender) {
+		fo.dir = dir
+	}
+}

--- a/wrap.go
+++ b/wrap.go
@@ -20,6 +20,6 @@ func Wrap(sender mail.Sender) mail.Sender {
 
 	return FileSender{
 		Open: true,
-		dir:  os.TempDir(),
+		dir:  getEnv(MailOpenDirKey, os.TempDir()),
 	}
 }

--- a/wrap.go
+++ b/wrap.go
@@ -19,7 +19,7 @@ func Wrap(sender mail.Sender) mail.Sender {
 	}
 
 	return FileSender{
-		Open:    true,
-		TempDir: os.TempDir(),
+		Open: true,
+		dir:  os.TempDir(),
 	}
 }


### PR DESCRIPTION
This pull request adds a new feature that allows users to specify a custom directory for mailopen's templates and attachments.

#13 